### PR TITLE
Selenium

### DIFF
--- a/petclinic_spec.rb
+++ b/petclinic_spec.rb
@@ -32,7 +32,7 @@ describe 'Petlinic' do
   end
 
   describe 'when homepage is available' do
-    it 'should have veterinarians page' do
+    it 'should have Veterinarians page' do
       @driver.find_element(:class, 'icon-th-list').click
       @driver.find_element(:link_text, 'View as XML')
       h2 = @driver.find_element(:tag_name, 'h2')
@@ -41,7 +41,7 @@ describe 'Petlinic' do
   end
 
   describe 'when homepage is available' do
-    it 'should have search for veterinarian feature' do
+    it 'should have Search for Veterinarian feature' do
       @driver.find_element(:class, 'icon-th-list').click
       @driver.find_element(:tag_name, 'input').send_keys('Helen Leary')
       result = @driver.find_element(:css, 'td.sorting_1').text

--- a/petclinic_spec.rb
+++ b/petclinic_spec.rb
@@ -18,7 +18,6 @@ describe 'Petlinic' do
 
   describe 'when homepage is available' do
     it 'should show correct page title' do
-      sleep 3
       assert @driver.title == 'PetClinic :: a Spring Framework demonstration'
     end
   end
@@ -26,7 +25,7 @@ describe 'Petlinic' do
   describe 'when homepage is available' do
     it 'should have Find Owners page' do
       @driver.find_element(:class, 'icon-search').click
-      sleep 3
+      @driver.find_element(:link_text, 'Add Owner')
       h2 = @driver.find_element(:tag_name, 'h2')
       assert h2.text == 'Find Owners'
     end
@@ -35,7 +34,7 @@ describe 'Petlinic' do
   describe 'when homepage is available' do
     it 'should have veterinarians page' do
       @driver.find_element(:class, 'icon-th-list').click
-      sleep 3
+      @driver.find_element(:link_text, 'View as XML')
       h2 = @driver.find_element(:tag_name, 'h2')
       assert h2.text == 'Veterinarians'
     end

--- a/petclinic_spec.rb
+++ b/petclinic_spec.rb
@@ -44,12 +44,9 @@ describe 'Petlinic' do
   describe 'when homepage is available' do
       it 'should have search for veterinarian feature' do
           @driver.find_element(:class, 'icon-th-list').click
-          search_box = @driver.find_element(:id, 'vets_filter')
-          textBox = search_box.find_element(:tag_name, 'input')
-          textBox.send_keys('Helen Leary')
-          vets = @driver.find_element(:id, 'vets').text
-          assert vets.split("\n")[1] == 'Helen Leary radiology'
+          @driver.find_element(:tag_name, 'input').send_keys('Helen Leary')
+          result = @driver.find_element(:css, 'td.sorting_1').text
+          assert result == 'Helen Leary'
       end
   end
-
 end

--- a/petclinic_spec.rb
+++ b/petclinic_spec.rb
@@ -1,6 +1,5 @@
 require 'headless'
 require 'selenium-webdriver'
-require 'minitest/spec'
 require 'minitest/autorun'
 
 describe 'Petlinic' do
@@ -10,7 +9,6 @@ describe 'Petlinic' do
 
     @driver = Selenium::WebDriver.for :firefox
     @driver.navigate.to 'http://tomcat:8080/petclinic'
-    @wait = Selenium::WebDriver::Wait.new(:timeout => 30)
     @driver.manage.timeouts.implicit_wait = 30
   end
 
@@ -19,38 +17,38 @@ describe 'Petlinic' do
   end
 
   describe 'when homepage is available' do
-    it 'I should see page title containing PetClinic' do
+    it 'should show correct page title' do
         sleep 3
-        assert @driver.title == "PetClinic :: a Spring Framework demonstration"
+        assert @driver.title == 'PetClinic :: a Spring Framework demonstration'
     end
   end
 
   describe 'when homepage is available' do
-    it 'click the find owners link' do
-        @driver.find_element(:class, "icon-search").click
+    it 'should have Find Owners page' do
+        @driver.find_element(:class, 'icon-search').click
         sleep 3
-        h2 = @driver.find_element(:tag_name, "h2")
-        assert h2.text == "Find Owners"
+        h2 = @driver.find_element(:tag_name, 'h2')
+        assert h2.text == 'Find Owners'
     end
   end
 
   describe 'when homepage is available' do
-      it 'click the veterinarians link' do
-          @driver.find_element(:class, "icon-th-list").click
+      it 'should have veterinarians page' do
+          @driver.find_element(:class, 'icon-th-list').click
           sleep 3
-          h2 = @driver.find_element(:tag_name, "h2")
-          assert h2.text == "Veterinarians"
+          h2 = @driver.find_element(:tag_name, 'h2')
+          assert h2.text == 'Veterinarians'
       end
   end
 
   describe 'when homepage is available' do
-      it 'search for veterinarian' do
-          @driver.find_element(:class, "icon-th-list").click
-          search_box = @driver.find_element(:id, "vets_filter")
-          textBox = search_box.find_element(:tag_name, "input")
-          textBox.send_keys("Helen Leary")
-          vets = @driver.find_element(:id, "vets").text
-          assert vets.split("\n")[1] == "Helen Leary radiology"
+      it 'should have search for veterinarian feature' do
+          @driver.find_element(:class, 'icon-th-list').click
+          search_box = @driver.find_element(:id, 'vets_filter')
+          textBox = search_box.find_element(:tag_name, 'input')
+          textBox.send_keys('Helen Leary')
+          vets = @driver.find_element(:id, 'vets').text
+          assert vets.split("\n")[1] == 'Helen Leary radiology'
       end
   end
 

--- a/petclinic_spec.rb
+++ b/petclinic_spec.rb
@@ -18,35 +18,35 @@ describe 'Petlinic' do
 
   describe 'when homepage is available' do
     it 'should show correct page title' do
-        sleep 3
-        assert @driver.title == 'PetClinic :: a Spring Framework demonstration'
+      sleep 3
+      assert @driver.title == 'PetClinic :: a Spring Framework demonstration'
     end
   end
 
   describe 'when homepage is available' do
     it 'should have Find Owners page' do
-        @driver.find_element(:class, 'icon-search').click
-        sleep 3
-        h2 = @driver.find_element(:tag_name, 'h2')
-        assert h2.text == 'Find Owners'
+      @driver.find_element(:class, 'icon-search').click
+      sleep 3
+      h2 = @driver.find_element(:tag_name, 'h2')
+      assert h2.text == 'Find Owners'
     end
   end
 
   describe 'when homepage is available' do
-      it 'should have veterinarians page' do
-          @driver.find_element(:class, 'icon-th-list').click
-          sleep 3
-          h2 = @driver.find_element(:tag_name, 'h2')
-          assert h2.text == 'Veterinarians'
-      end
+    it 'should have veterinarians page' do
+      @driver.find_element(:class, 'icon-th-list').click
+      sleep 3
+      h2 = @driver.find_element(:tag_name, 'h2')
+      assert h2.text == 'Veterinarians'
+    end
   end
 
   describe 'when homepage is available' do
-      it 'should have search for veterinarian feature' do
-          @driver.find_element(:class, 'icon-th-list').click
-          @driver.find_element(:tag_name, 'input').send_keys('Helen Leary')
-          result = @driver.find_element(:css, 'td.sorting_1').text
-          assert result == 'Helen Leary'
-      end
+    it 'should have search for veterinarian feature' do
+      @driver.find_element(:class, 'icon-th-list').click
+      @driver.find_element(:tag_name, 'input').send_keys('Helen Leary')
+      result = @driver.find_element(:css, 'td.sorting_1').text
+      assert result == 'Helen Leary'
+    end
   end
 end

--- a/petclinic_spec.rb
+++ b/petclinic_spec.rb
@@ -22,29 +22,47 @@ describe 'Petlinic' do
     end
   end
 
-  describe 'when homepage is available' do
+  describe 'when site is available' do
     it 'should have Find Owners page' do
+      # click on Find Owners menu item
       @driver.find_element(:class, 'icon-search').click
+
+      # wait to see Add Owner on the page that opens
       @driver.find_element(:link_text, 'Add Owner')
-      h2 = @driver.find_element(:tag_name, 'h2')
-      assert h2.text == 'Find Owners'
+
+      # grab H2 content
+      h2 = @driver.find_element(:tag_name, 'h2').text
+
+      assert h2 == 'Find Owners'
     end
   end
 
-  describe 'when homepage is available' do
+  describe 'when site is available' do
     it 'should have Veterinarians page' do
+      # click on Veterinarian menu item
       @driver.find_element(:class, 'icon-th-list').click
+
+      # wait to see View as XML on the page that opens
       @driver.find_element(:link_text, 'View as XML')
-      h2 = @driver.find_element(:tag_name, 'h2')
-      assert h2.text == 'Veterinarians'
+
+      # grab H2 content
+      h2 = @driver.find_element(:tag_name, 'h2').text
+
+      assert h2 == 'Veterinarians'
     end
   end
 
-  describe 'when homepage is available' do
+  describe 'when site is available' do
     it 'should have Search for Veterinarian feature' do
+      # click on Veterinarian menu item
       @driver.find_element(:class, 'icon-th-list').click
+
+      # type Veterinarian name in search box
       @driver.find_element(:tag_name, 'input').send_keys('Helen Leary')
+
+      # grab first cell content in filtered results
       result = @driver.find_element(:css, 'td.sorting_1').text
+
       assert result == 'Helen Leary'
     end
   end


### PR DESCRIPTION
In order to grab H2 only on the expected page we need to wait for unique element of that page to show up.
Previously, since each page have H2 tag, it would find it even tho the old page is till present after clicking on the menu item (and would have h2 on it).
Since using implicit wait, waiting for unique element of the expected page to show up fixes the timing issue.