### PR TITLE
ECS Deployments LDOP-101

### DIFF
--- a/ecs-compose.yml
+++ b/ecs-compose.yml
@@ -1,0 +1,6 @@
+spring-petclinic:
+  image: shanem/spring-petclinic
+  cpu_shares: 100
+  mem_limit: 262144000
+  ports:
+    - "80:8080"

--- a/ecs-compose.yml
+++ b/ecs-compose.yml
@@ -1,3 +1,4 @@
+# Does not support build derivative
 spring-petclinic:
   image: shanem/spring-petclinic:latest
   cpu_shares: 100

--- a/ecs-compose.yml
+++ b/ecs-compose.yml
@@ -1,5 +1,5 @@
 spring-petclinic:
-  image: shanem/spring-petclinic
+  image: shanem/spring-petclinic:latest
   cpu_shares: 100
   mem_limit: 262144000
   ports:

--- a/ecs-compose.yml
+++ b/ecs-compose.yml
@@ -1,6 +1,6 @@
 # Does not support build derivative
 spring-petclinic:
-  image: shanem/spring-petclinic:latest
+  image: liatrio/ecs-spring-petclinic:latest
   cpu_shares: 100
   mem_limit: 262144000
   ports:

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -42,7 +42,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh '''ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}''''
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
         }
       }
     }
@@ -57,7 +57,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh '''ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}''''
+          sh """ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
           input 'Deploy to ECS Production?'
         }
       }
@@ -73,7 +73,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh '''ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}''''
+          sh """ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
         }
       }
     }
@@ -87,9 +87,9 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh '''ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}''''
-          sh '''ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}''''
-          sh '''ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}''''
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
           echo "To delete resources allocated run: ecs-cli down --force"
         }
       }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -19,14 +19,14 @@ pipeline {
     stage('Deploy to ECS Development') {
       agent {
         docker {
-          image 'some-repo/ecs-cli'
+          image 'liatrio/ecs-cli'
           args  '-u 0:0'
         }
       }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "# run docker compose for dev"
+          sh "ecs-cli --version"
           echo "Should be accessible at DEV URL"
           input 'Deploy to ECS Production?'
         }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -27,7 +27,7 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli --version"
+          sh "ecs-cli up --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
         }
       }
     }
@@ -41,7 +41,7 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli --version"
+          sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
           echo "Should be accessible at DEV URL"
         }
       }
@@ -56,7 +56,7 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli --version"
+          sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
           echo "Should be accessible at QA URL"
           input 'Deploy to ECS Production?'
         }
@@ -72,7 +72,7 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli --version"
+          sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
           echo "Should be accessible at PROD URL"
         }
       }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,5 +1,16 @@
 #!groovy
-// Assumes that there is an AWS EC2 key pair with the id ecs
+/*
+ *  Author:
+ *
+ *    Shane MacBride @shanemacbride <shanem@liatrio.com>
+ *
+ *  Requirements:
+ *
+ *    "DockerHub" Jenkins Credentials
+ *    "ECS"       Jenkins Credentials
+ *    "ecs"       AWS EC2 Keypair
+ *
+*/
 pipeline {
   agent none 
   stages {

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,4 +1,5 @@
 #!groovy
+// Assumes that there is an AWS EC2 key pair with the id ecs
 pipeline {
   agent none
   stages {

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,73 +1,74 @@
 #!groovy
 // Assumes that there is an AWS EC2 key pair with the id ecs
 pipeline {
-	agent {
-		docker {
-			image 'liatrio/ecs-cli'
-			args  '-u 0:0'
-		}
-	}
-	stages {
-		stage('Build') {
-			agent {
-				docker {
-					image 'maven:3.5.0'
-					args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
-				}
-			}
-			steps {
-				configFileProvider(
-					[configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
-					sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
-					}
-			}
-		}
-		stage('Create ECS Cluster') {
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
-				}
-			}
-		}
-		stage('Deploy to ECS DEV') {
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-				}
-			}
-		}
-		stage('Deploy to ECS QA') {
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-					input 'Deploy to ECS Production?'
-				}
-			}
-		}
-		stage('Deploy to ECS PROD') {
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-				}
-			}
-		}
-		stage('Output Results') {
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-					echo "To delete resources allocated run: ecs-cli down --force"
-				}
-			}
-		}
-	}
+  agent none 
+  stages {
+    stage('Build') {
+      agent {
+        docker {
+          image 'maven:3.5.0'
+          args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+        }
+      }
+      steps {
+        configFileProvider(
+          [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+          sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
+          }
+      }
+    }
+    agent {
+      docker {
+        image 'liatrio/ecs-cli'
+        args  '-u 0:0'
+      }
+    }
+    stage('Create ECS Cluster') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
+        }
+      }
+    }
+    stage('Deploy to ECS DEV') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
+          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+        }
+      }
+    }
+    stage('Deploy to ECS QA') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
+          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+          input 'Deploy to ECS Production?'
+        }
+      }
+    }
+    stage('Deploy to ECS PROD') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
+          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+        }
+      }
+    }
+    stage('Output Results') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+          echo "To delete resources allocated run: ecs-cli down --force"
+        }
+      }
+    }
+  }
 }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -17,13 +17,13 @@ pipeline {
           }
       }
     }
-    agent {
-      docker {
-        image 'liatrio/ecs-cli'
-        args  '-u 0:0'
-      }
-    }
     stage('Create ECS Cluster') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -32,6 +32,12 @@ pipeline {
       }
     }
     stage('Deploy to ECS DEV') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -41,6 +47,12 @@ pipeline {
       }
     }
     stage('Deploy to ECS QA') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -51,6 +63,12 @@ pipeline {
       }
     }
     stage('Deploy to ECS PROD') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -60,6 +78,12 @@ pipeline {
       }
     }
     stage('Output Results') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,59 +1,73 @@
 #!groovy
 // Assumes that there is an AWS EC2 key pair with the id ecs
 pipeline {
-  agent {
-    docker {
-      image 'liatrio/ecs-cli'
-      args  '-u 0:0'
-    }
-  }
-  stages {
-    stage('Create ECS Cluster') {
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
-        }
-      }
-    }
-    stage('Deploy to ECS DEV') {
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-        }
-      }
-    }
-    stage('Deploy to ECS QA') {
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-          input 'Deploy to ECS Production?'
-        }
-      }
-    }
-    stage('Deploy to ECS PROD') {
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-        }
-      }
-    }
-    stage('Output Results') {
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-          echo "To delete resources allocated run: ecs-cli down --force"
-        }
-      }
-    }
-  }
+	agent {
+		docker {
+			image 'liatrio/ecs-cli'
+			args  '-u 0:0'
+		}
+	}
+	stages {
+		stage('Build') {
+			agent {
+				docker {
+					image 'maven:3.5.0'
+					args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+				}
+			}
+			steps {
+				configFileProvider(
+					[configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+					sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
+					}
+			}
+		}
+		stage('Create ECS Cluster') {
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
+				}
+			}
+		}
+		stage('Deploy to ECS DEV') {
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
+					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+				}
+			}
+		}
+		stage('Deploy to ECS QA') {
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
+					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+					input 'Deploy to ECS Production?'
+				}
+			}
+		}
+		stage('Deploy to ECS PROD') {
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
+					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+				}
+			}
+		}
+		stage('Output Results') {
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+					echo "To delete resources allocated run: ecs-cli down --force"
+				}
+			}
+		}
+	}
 }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,0 +1,36 @@
+#!groovy
+pipeline {
+  agent none
+  stages {
+    stage('Build') {
+      agent {
+        docker {
+          image 'maven:3.5.0'
+          args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+        }
+      }
+      steps {
+        configFileProvider(
+          [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+          sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
+          }
+      }
+    }
+    stage('Deploy to ECS Development') {
+      agent {
+        docker {
+          image 'some-repo/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "# run docker compose for dev"
+          echo "Should be accessible at DEV URL"
+          input 'Deploy to ECS Production?'
+        }
+      }
+    }
+  }
+}

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,98 +1,121 @@
 #!groovy
 // Assumes that there is an AWS EC2 key pair with the id ecs
 pipeline {
-  agent none 
-  stages {
-    stage('Build') {
-      agent {
-        docker {
-          image 'maven:3.5.0'
-          args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
-        }
-      }
-      steps {
-        configFileProvider(
-          [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
-          sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
-          }
-      }
-    }
-    stage('Create ECS Cluster') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
-        }
-      }
-    }
-    stage('Deploy to ECS DEV') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-        }
-      }
-    }
-    stage('Deploy to ECS QA') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-          input 'Deploy to ECS Production?'
-        }
-      }
-    }
-    stage('Deploy to ECS PROD') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-        }
-      }
-    }
-    stage('Output Results') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-          echo "To delete resources allocated run: ecs-cli down --force"
-        }
-      }
-    }
-  }
+	agent none 
+	stages {
+		stage('Build') {
+			agent {
+				docker {
+					image 'maven:3.5.0'
+					args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+				}
+			}
+			steps {
+				configFileProvider(
+					[configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+					sh 'mvn -s $MAVEN_SETTINGS clean deploy -DskipTests=true -B'
+					}
+			}
+		}
+		stage('Sonar') {
+			agent  {
+				docker {
+					image 'sebp/sonar-runner'
+					args '-e SONAR_ACCOUNT_LOGIN -e SONAR_ACCOUNT_PASSWORD -e SONAR_DB_URL -e SONAR_DB_LOGIN -e SONAR_DB_PASSWORD --network=${LDOP_NETWORK_NAME}'
+				}
+			}
+			steps {
+				sh '/opt/sonar-runner-2.4/bin/sonar-runner -e -D sonar.login=${SONAR_ACCOUNT_LOGIN} -D sonar.password=${SONAR_ACCOUNT_PASSWORD} -D sonar.jdbc.url=${SONAR_DB_URL} -D sonar.jdbc.username=${SONAR_DB_LOGIN} -D sonar.jdbc.password=${SONAR_DB_PASSWORD}'
+			}
+		}
+		stage('Docker Build') {
+			agent any
+			steps {
+				sh 'docker build -t liatrio/ecs-spring-petclinic:latest .'
+			}
+		}
+		stage('Docker Push') {
+			agent any
+			steps {
+				sh 'docker push liatrio/ecs-spring-petclinic:latest'
+			}
+		}
+		stage('Create ECS Cluster') {
+			agent {
+				docker {
+					image 'liatrio/ecs-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
+				}
+			}
+		}
+		stage('Deploy to ECS DEV') {
+			agent {
+				docker {
+					image 'liatrio/ecs-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
+					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+				}
+			}
+		}
+		stage('Deploy to ECS QA') {
+			agent {
+				docker {
+					image 'liatrio/ecs-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
+					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+					input 'Deploy to ECS Production?'
+				}
+			}
+		}
+		stage('Deploy to ECS PROD') {
+			agent {
+				docker {
+					image 'liatrio/ecs-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
+					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+				}
+			}
+		}
+		stage('Output Results') {
+			agent {
+				docker {
+					image 'liatrio/ecs-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+					echo "To delete resources allocated run: ecs-cli down --force"
+				}
+			}
+		}
+	}
 }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,121 +1,124 @@
 #!groovy
 // Assumes that there is an AWS EC2 key pair with the id ecs
 pipeline {
-	agent none 
-	stages {
-		stage('Build') {
-			agent {
-				docker {
-					image 'maven:3.5.0'
-					args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
-				}
-			}
-			steps {
-				configFileProvider(
-					[configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
-					sh 'mvn -s $MAVEN_SETTINGS clean deploy -DskipTests=true -B'
-					}
-			}
-		}
-		stage('Sonar') {
-			agent  {
-				docker {
-					image 'sebp/sonar-runner'
-					args '-e SONAR_ACCOUNT_LOGIN -e SONAR_ACCOUNT_PASSWORD -e SONAR_DB_URL -e SONAR_DB_LOGIN -e SONAR_DB_PASSWORD --network=${LDOP_NETWORK_NAME}'
-				}
-			}
-			steps {
-				sh '/opt/sonar-runner-2.4/bin/sonar-runner -e -D sonar.login=${SONAR_ACCOUNT_LOGIN} -D sonar.password=${SONAR_ACCOUNT_PASSWORD} -D sonar.jdbc.url=${SONAR_DB_URL} -D sonar.jdbc.username=${SONAR_DB_LOGIN} -D sonar.jdbc.password=${SONAR_DB_PASSWORD}'
-			}
-		}
-		stage('Docker Build') {
-			agent any
-			steps {
-				sh 'docker build -t liatrio/ecs-spring-petclinic:latest .'
-			}
-		}
-		stage('Docker Push') {
-			agent any
-			steps {
-				sh 'docker push liatrio/ecs-spring-petclinic:latest'
-			}
-		}
-		stage('Create ECS Cluster') {
-			agent {
-				docker {
-					image 'liatrio/ecs-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
-				}
-			}
-		}
-		stage('Deploy to ECS DEV') {
-			agent {
-				docker {
-					image 'liatrio/ecs-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-				}
-			}
-		}
-		stage('Deploy to ECS QA') {
-			agent {
-				docker {
-					image 'liatrio/ecs-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-					input 'Deploy to ECS Production?'
-				}
-			}
-		}
-		stage('Deploy to ECS PROD') {
-			agent {
-				docker {
-					image 'liatrio/ecs-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-				}
-			}
-		}
-		stage('Output Results') {
-			agent {
-				docker {
-					image 'liatrio/ecs-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
-					sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-					sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-					sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-					sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
-					echo "To delete resources allocated run: ecs-cli down --force"
-				}
-			}
-		}
-	}
+  agent none 
+  stages {
+    stage('Build') {
+      agent {
+        docker {
+          image 'maven:3.5.0'
+          args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+        }
+      }
+      steps {
+        configFileProvider(
+          [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+          sh 'mvn -s $MAVEN_SETTINGS clean deploy -DskipTests=true -B'
+          }
+      }
+    }
+    stage('Sonar') {
+      agent  {
+        docker {
+          image 'sebp/sonar-runner'
+          args '-e SONAR_ACCOUNT_LOGIN -e SONAR_ACCOUNT_PASSWORD -e SONAR_DB_URL -e SONAR_DB_LOGIN -e SONAR_DB_PASSWORD --network=${LDOP_NETWORK_NAME}'
+        }
+      }
+      steps {
+        sh '/opt/sonar-runner-2.4/bin/sonar-runner -e -D sonar.login=${SONAR_ACCOUNT_LOGIN} -D sonar.password=${SONAR_ACCOUNT_PASSWORD} -D sonar.jdbc.url=${SONAR_DB_URL} -D sonar.jdbc.username=${SONAR_DB_LOGIN} -D sonar.jdbc.password=${SONAR_DB_PASSWORD}'
+      }
+    }
+    stage('Docker Build') {
+      agent any
+      steps {
+        sh 'docker build -t liatrio/ecs-spring-petclinic:latest .'
+      }
+    }
+    stage('Docker Push') {
+      agent any
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'DockerHub', passwordVariable: 'dockerPassword', usernameVariable: 'dockerUsername')]){
+          sh "docker login -u ${env.dockerUsername} -p ${env.dockerPassword}"
+          sh 'docker push liatrio/ecs-spring-petclinic:latest'
+        }
+      }
+    }
+    stage('Create ECS Cluster') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
+        }
+      }
+    }
+    stage('Deploy to ECS DEV') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
+          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+        }
+      }
+    }
+    stage('Deploy to ECS QA') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
+          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+          input 'Deploy to ECS Production?'
+        }
+      }
+    }
+    stage('Deploy to ECS PROD') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
+          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+        }
+      }
+    }
+    stage('Output Results') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+          echo "To delete resources allocated run: ecs-cli down --force"
+        }
+      }
+    }
+  }
 }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -42,7 +42,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"\$1"/petclinic"}'"""
         }
       }
     }
@@ -57,7 +57,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"\$1"/petclinic"}'"""
           input 'Deploy to ECS Production?'
         }
       }
@@ -73,7 +73,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"\$1"/petclinic"}'"""
         }
       }
     }
@@ -87,9 +87,9 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
-          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
-          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"\$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"\$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"\$1"/petclinic"}'"""
           echo "To delete resources allocated run: ecs-cli down --force"
         }
       }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -42,7 +42,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
         }
       }
     }
@@ -57,7 +57,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
           input 'Deploy to ECS Production?'
         }
       }
@@ -73,7 +73,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
         }
       }
     }
@@ -87,9 +87,9 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
-          sh """ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
-          sh """ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}'"""
           echo "To delete resources allocated run: ecs-cli down --force"
         }
       }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -42,7 +42,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          echo "Should be accessible at DEV URL"
+          sh '''ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}''''
         }
       }
     }
@@ -57,7 +57,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          echo "Should be accessible at QA URL"
+          sh '''ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}''''
           input 'Deploy to ECS Production?'
         }
       }
@@ -73,7 +73,24 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          echo "Should be accessible at PROD URL"
+          sh '''ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}''''
+        }
+      }
+    }
+    stage('Output Results') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh '''ecs-cli ps | grep dev | awk -F' ' '{print $3}' | awk -F':' '{print "DEV URL: http://"$1"/petclinic"}''''
+          sh '''ecs-cli ps | grep qa | awk -F' ' '{print $3}' | awk -F':' '{print "QA URL: http://"$1"/petclinic"}''''
+          sh '''ecs-cli ps | grep prod | awk -F' ' '{print $3}' | awk -F':' '{print "PROD URL: http://"$1"/petclinic"}''''
+          echo "To delete resources allocated run: ecs-cli down --force"
         }
       }
     }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -27,7 +27,7 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh "ecs-cli up --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
+          sh "ecs-cli up --force --keypair ecs --capability-iam --size 3 --instance-type t2.micro"
         }
       }
     }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -21,7 +21,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
         }
       }
     }
@@ -30,7 +30,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"\$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
           input 'Deploy to ECS Production?'
         }
       }
@@ -40,7 +40,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"\$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
         }
       }
     }
@@ -48,9 +48,9 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"\$1"/petclinic"}'"""
-          sh """ecs-cli ps | grep qa | awk -F' ' '{print \$3}' | awk -F':' '{print "QA URL: http://"\$1"/petclinic"}'"""
-          sh """ecs-cli ps | grep prod | awk -F' ' '{print \$3}' | awk -F':' '{print "PROD URL: http://"\$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
           echo "To delete resources allocated run: ecs-cli down --force"
         }
       }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -21,7 +21,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print \"DEV URL: http://\"\$1\"/petclinic\"}'"""
+          sh """ecs-cli ps | grep dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
         }
       }
     }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -79,7 +79,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
+          sh "ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"
         }
       }
     }
@@ -94,7 +94,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-qa --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
+          sh "ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"
           input 'Deploy to ECS Production?'
         }
       }
@@ -110,7 +110,7 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-prod --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+          sh "ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"
         }
       }
     }
@@ -124,9 +124,9 @@ pipeline {
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
-          sh """ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"""
-          sh """ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"""
-          sh """ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"""
+          sh "ecs-cli ps | grep -m 1 dev | awk -F'RUNNING  |:' '{print \"DEV URL: http://\"\$2\"/petclinic\"}'"
+          sh "ecs-cli ps | grep -m 1 qa | awk -F'RUNNING  |:' '{print \"QA URL: http://\"\$2\"/petclinic\"}'"
+          sh "ecs-cli ps | grep -m 1 prod | awk -F'RUNNING  |:' '{print \"PROD URL: http://\"\$2\"/petclinic\"}'"
           echo "To delete resources allocated run: ecs-cli down --force"
         }
       }

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -1,29 +1,14 @@
 #!groovy
 // Assumes that there is an AWS EC2 key pair with the id ecs
 pipeline {
-  agent none
-  stages {
-    stage('Build') {
-      agent {
-        docker {
-          image 'maven:3.5.0'
-          args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
-        }
-      }
-      steps {
-        configFileProvider(
-          [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
-          sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
-          }
-      }
+  agent {
+    docker {
+      image 'liatrio/ecs-cli'
+      args  '-u 0:0'
     }
+  }
+  stages {
     stage('Create ECS Cluster') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -32,27 +17,15 @@ pipeline {
       }
     }
     stage('Deploy to ECS DEV') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli compose --project-name spring-petclinic-dev --file ecs-compose.yml up"
-          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print "DEV URL: http://"\$1"/petclinic"}'"""
+          sh """ecs-cli ps | grep dev | awk -F' ' '{print \$3}' | awk -F':' '{print \"DEV URL: http://\"\$1\"/petclinic\"}'"""
         }
       }
     }
     stage('Deploy to ECS QA') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -63,12 +36,6 @@ pipeline {
       }
     }
     stage('Deploy to ECS PROD') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
@@ -78,12 +45,6 @@ pipeline {
       }
     }
     stage('Output Results') {
-      agent {
-        docker {
-          image 'liatrio/ecs-cli'
-          args  '-u 0:0'
-        }
-      }
       steps {
         withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"

--- a/jenkinsfiles/ecs
+++ b/jenkinsfiles/ecs
@@ -16,7 +16,21 @@ pipeline {
           }
       }
     }
-    stage('Deploy to ECS Development') {
+    stage('Create ECS Cluster') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli --version"
+        }
+      }
+    }
+    stage('Deploy to ECS DEV') {
       agent {
         docker {
           image 'liatrio/ecs-cli'
@@ -28,7 +42,37 @@ pipeline {
           sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
           sh "ecs-cli --version"
           echo "Should be accessible at DEV URL"
+        }
+      }
+    }
+    stage('Deploy to ECS QA') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli --version"
+          echo "Should be accessible at QA URL"
           input 'Deploy to ECS Production?'
+        }
+      }
+    }
+    stage('Deploy to ECS PROD') {
+      agent {
+        docker {
+          image 'liatrio/ecs-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'ECS', passwordVariable: 'awsSecret', usernameVariable: 'awsAccess')]){
+          sh "ecs-cli configure --region us-west-2 --access-key ${env.awsAccess} --secret-key ${env.awsSecret} --cluster petclinic-cluster"
+          sh "ecs-cli --version"
+          echo "Should be accessible at PROD URL"
         }
       }
     }

--- a/jenkinsfiles/pivotal
+++ b/jenkinsfiles/pivotal
@@ -1,51 +1,61 @@
 #!groovy
+/*
+ *  Author:
+ *
+ *    Shane MacBride @shanemacbride <shanem@liatrio.com?
+ *
+ *  Requirements:
+ *
+ *    "pivotal"  Jenkins Credentials
+ *
+*/
 pipeline {
-	agent none
-	stages {
-		stage('Build') {
-			agent {
-				docker {
-					image 'maven:3.5.0'
-					args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
-				}
-			}
-			steps {
-				configFileProvider(
-					[configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
-					sh 'mvn -s $MAVEN_SETTINGS clean deploy -DskipTests=true -B'
-					}
-			}
-		}
-		stage('Deploy to Pivotal Development') {
-			agent {
-				docker {
-					image 'liatrio/cf-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
-					sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
-					sh 'cf push -f ./base-manifest.yml'
-					echo "Should be accessible at http://pivotal-dev.liatr.io"
-					input 'Deploy to Pivotal Prod?'
-				}
-			}
-		}
-		stage('Deploy to Pivotal Prod') {
-			agent {
-				docker {
-					image 'liatrio/cf-cli'
-					args  '-u 0:0'
-				}
-			}
-			steps {
-				withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
-					sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
-					sh 'cf push -f ./prod-manifest.yml'
-					echo "Should be accessible at http://pivotal-prod.liatr.io"
-				}
-			}
-		}
-	}
+  agent none
+  stages {
+    stage('Build') {
+      agent {
+        docker {
+          image 'maven:3.5.0'
+          args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+        }
+      }
+      steps {
+        configFileProvider(
+          [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+          sh 'mvn -s $MAVEN_SETTINGS clean deploy -DskipTests=true -B'
+          }
+      }
+    }
+    stage('Deploy to Pivotal Development') {
+      agent {
+        docker {
+          image 'liatrio/cf-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
+          sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
+          sh 'cf push -f ./base-manifest.yml'
+          echo "Should be accessible at http://pivotal-dev.liatr.io"
+          input 'Deploy to Pivotal Prod?'
+        }
+      }
+    }
+    stage('Deploy to Pivotal Prod') {
+      agent {
+        docker {
+          image 'liatrio/cf-cli'
+          args  '-u 0:0'
+        }
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
+          sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
+          sh 'cf push -f ./prod-manifest.yml'
+          echo "Should be accessible at http://pivotal-prod.liatr.io"
+        }
+      }
+    }
+  }
 }

--- a/jenkinsfiles/pivotal
+++ b/jenkinsfiles/pivotal
@@ -2,7 +2,7 @@
 /*
  *  Author:
  *
- *    Shane MacBride @shanemacbride <shanem@liatrio.com?
+ *    Shane MacBride @shanemacbride <shanem@liatrio.com>
  *
  *  Requirements:
  *

--- a/jenkinsfiles/pivotal
+++ b/jenkinsfiles/pivotal
@@ -1,51 +1,51 @@
 #!groovy
 pipeline {
-    agent none
-    stages {
-       stage('Build') {
-           agent {
-               docker {
-                   image 'maven:3.5.0'
-                   args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
-               }
-           }
-           steps {
-               configFileProvider(
-                       [configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
-                   sh 'mvn -s $MAVEN_SETTINGS clean install -DskipTests=true -B'
-               }
-           }
-       }
-       stage('Deploy to Pivotal Development') {
-           agent {
-               docker {
-                   image 'liatrio/cf-cli'
-                   args  '-u 0:0'
-               }
-           }
-           steps {
-               withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
-                 sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
-                 sh 'cf push -f ./base-manifest.yml'
-                 echo "Should be accessible at http://pivotal-dev.liatr.io"
-                 input 'Deploy to Pivotal Prod?'
-           }
-         }
-       }
-       stage('Deploy to Pivotal Prod') {
-           agent {
-               docker {
-                   image 'liatrio/cf-cli'
-                   args  '-u 0:0'
-               }
-           }
-           steps {
-               withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
-                 sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
-                 sh 'cf push -f ./prod-manifest.yml'
-                 echo "Should be accessible at http://pivotal-prod.liatr.io"
-        }
-      }
-    }
-  }
+	agent none
+	stages {
+		stage('Build') {
+			agent {
+				docker {
+					image 'maven:3.5.0'
+					args '-e INITIAL_ADMIN_USER -e INITIAL_ADMIN_PASSWORD --network=${LDOP_NETWORK_NAME}'
+				}
+			}
+			steps {
+				configFileProvider(
+					[configFile(fileId: 'nexus', variable: 'MAVEN_SETTINGS')]) {
+					sh 'mvn -s $MAVEN_SETTINGS clean deploy -DskipTests=true -B'
+					}
+			}
+		}
+		stage('Deploy to Pivotal Development') {
+			agent {
+				docker {
+					image 'liatrio/cf-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
+					sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
+					sh 'cf push -f ./base-manifest.yml'
+					echo "Should be accessible at http://pivotal-dev.liatr.io"
+					input 'Deploy to Pivotal Prod?'
+				}
+			}
+		}
+		stage('Deploy to Pivotal Prod') {
+			agent {
+				docker {
+					image 'liatrio/cf-cli'
+					args  '-u 0:0'
+				}
+			}
+			steps {
+				withCredentials([usernamePassword(credentialsId: 'pivotal', passwordVariable: 'pivotalPASSWORD', usernameVariable: 'pivotalUSERNAME')]){
+					sh "cf api https://api.run.pivotal.io && cf login -u ${env.pivotalUSERNAME} -p ${env.pivotalPASSWORD}"
+					sh 'cf push -f ./prod-manifest.yml'
+					echo "Should be accessible at http://pivotal-prod.liatr.io"
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Two files were added:
  - `ecs-compose.yml`
  - `jenkinsfiles/ecs`

The ecs-cli easily deploys images from Docker Hub utilizing docker-compose files. The Jenkinsfile does this using an Alpine-based ecs-cli image (liatrio/ecs-cli) from Docker Hub.

The Jenkinsfile spins up an ECS cluster (three t2.micro instances) and deploys Spring-petclinic to three environments: Dev, QA, and Prod. The cluster is automatically deleted and recreated each time the Jenkinsfile runs. The cluster can be manually deleted using `ecs-cli down --force`. When an ECS cluster is deleted, all associated resources are deleted (AWS CF).

One existing file was modified:
  - `jenkinsfiles/pivotal`

The Pivotal Jenkinsfile was updated to deploy to Nexus instead of just installing.