### PR TITLE
LDOP-302 full-demo jenkinsfile now uses updated getArtifact.

### DIFF
--- a/jenkinsfiles/full-demo
+++ b/jenkinsfiles/full-demo
@@ -41,7 +41,7 @@ pipeline {
         sh 'mvn clean'
         script {
           pom = readMavenPom file: 'pom.xml'
-          getArtifact(pom.groupId, pom.artifactId, pom.version)
+          getArtifact(pom.groupId, pom.artifactId, pom.version, "petclinic")
         }
       }
     }


### PR DESCRIPTION
Spring petclinic full-demo jenkinsfile now uses the correct parameters for the getArtifact shared library function.